### PR TITLE
Version 0.7.0

### DIFF
--- a/usdmanager/constants.py
+++ b/usdmanager/constants.py
@@ -52,7 +52,8 @@ LINE_CHAR_LIMIT = 999
 
 # Truncate loading files with more lines than this.
 # Display can slow down and/or become unusable with too many lines.
-LINE_LIMIT = 10000
+# This number is less important than the total number of characters and can be overridden in Preferences.
+LINE_LIMIT = 50000
 
 # Truncate loading files with more total chars than this.
 # QString crashes at ~2.1 billion chars, but display slows down way before that.

--- a/usdmanager/preferences_dialog.py
+++ b/usdmanager/preferences_dialog.py
@@ -19,6 +19,7 @@ from Qt.QtCore import Slot, QRegExp
 from Qt.QtGui import QIcon, QRegExpValidator
 from Qt.QtWidgets import (QAbstractButton, QDialog, QDialogButtonBox, QFontDialog, QLineEdit, QMessageBox, QVBoxLayout)
 
+from .constants import LINE_LIMIT
 from .utils import loadUiWidget
 
 
@@ -77,6 +78,7 @@ class PreferencesDialog(QDialog):
         self.lineEditTextEditor.setText(parent.preferences['textEditor'])
         self.lineEditDiffTool.setText(parent.preferences['diffTool'])
         self.themeWidget.setChecked(parent.preferences['theme'] == "dark")
+        self.lineLimitSpinBox.setValue(parent.preferences['lineLimit'])
         self.updateFontLabel()
         
         # ----- Programs tab -----
@@ -188,6 +190,15 @@ class PreferencesDialog(QDialog):
             `bool`
         """
         return self.checkBox_autoCompleteAddressBar.isChecked()
+    
+    def getPrefLineLimit(self):
+        """
+        :Returns:
+            Number of lines to display before truncating a file.
+        :Rtype:
+            `int`
+        """
+        return self.lineLimitSpinBox.value()
     
     def getPrefSyntaxHighlighting(self):
         """
@@ -319,22 +330,23 @@ class PreferencesDialog(QDialog):
             self.deleteItems(self.extLayout)
             
             # Set other preferences in the GUI.
-            window = self.parent().window()
-            self.checkBox_parseLinks.setChecked(True)
-            self.checkBox_newTab.setChecked(False)
-            self.checkBox_syntaxHighlighting.setChecked(True)
-            self.checkBox_teletypeConversion.setChecked(True)
-            self.checkBox_lineNumbers.setChecked(True)
-            self.checkBox_showAllMessages.setChecked(True)
-            self.checkBox_showHiddenFiles.setChecked(False)
-            self.checkBox_autoCompleteAddressBar.setChecked(True)
-            self.lineEditTextEditor.setText(os.getenv("EDITOR", window.app.appConfig.get("textEditor", "nedit")))
-            self.lineEditDiffTool.setText(window.app.appConfig.get("diffTool", "xdiff"))
-            self.useSpacesCheckBox.setChecked(True)
-            self.useSpacesSpinBox.setValue(4)
+            default = self.parent().window().app.DEFAULTS
+            self.checkBox_parseLinks.setChecked(default['parseLinks'])
+            self.checkBox_newTab.setChecked(default['newTab'])
+            self.checkBox_syntaxHighlighting.setChecked(default['syntaxHighlighting'])
+            self.checkBox_teletypeConversion.setChecked(default['teletype'])
+            self.checkBox_lineNumbers.setChecked(default['lineNumbers'])
+            self.checkBox_showAllMessages.setChecked(default['showAllMessages'])
+            self.checkBox_showHiddenFiles.setChecked(default['showHiddenFiles'])
+            self.checkBox_autoCompleteAddressBar.setChecked(default['autoCompleteAddressBar'])
+            self.lineEditTextEditor.setText(default['textEditor'])
+            self.lineEditDiffTool.setText(default['diffTool'])
+            self.useSpacesCheckBox.setChecked(default['useSpaces'])
+            self.useSpacesSpinBox.setValue(default['tabSpaces'])
             self.themeWidget.setChecked(False)
-            self.docFont = window.defaultDocFont
+            self.docFont = default['font']
             self.updateFontLabel()
+            self.lineLimitSpinBox.setValue(default['lineLimit'])
             
             # Re-create file association fields with the default programs.
             self.populateProgsAndExts(self.parent().defaultPrograms)

--- a/usdmanager/preferences_dialog.ui
+++ b/usdmanager/preferences_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>463</width>
-    <height>574</height>
+    <height>450</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -36,42 +36,12 @@
       </attribute>
       <layout class="QVBoxLayout" name="layoutGeneral">
        <item>
-        <widget class="QCheckBox" name="checkBox_parseLinks">
-         <property name="toolTip">
-          <string>Parse files for links to other files. Disable for faster loading of larger files</string>
-         </property>
-         <property name="text">
-          <string>Parse links</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="checkBox_newTab">
          <property name="toolTip">
           <string>Open links in new tabs instead of the current tab</string>
          </property>
          <property name="text">
           <string>Open links in new tabs</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_syntaxHighlighting">
-         <property name="toolTip">
-          <string>Enable syntax highlighting. Disable for faster loading of larger files</string>
-         </property>
-         <property name="text">
-          <string>Enable syntax highlighting</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_teletypeConversion">
-         <property name="toolTip">
-          <string>Display teletype character codes properly in browse mode. Disable for faster loading of larger files</string>
-         </property>
-         <property name="text">
-          <string>Display teletype colors</string>
          </property>
         </widget>
        </item>
@@ -110,13 +80,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="checkBox_autoCompleteAddressBar">
-         <property name="text">
-          <string>Auto complete paths in address bar</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="useSpacesLayout">
          <item>
           <widget class="QCheckBox" name="useSpacesCheckBox">
@@ -144,6 +107,9 @@
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="buddy">
+            <cstring>useSpacesSpinBox</cstring>
            </property>
           </widget>
          </item>
@@ -264,8 +230,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>119</width>
-            <height>72</height>
+            <width>421</width>
+            <height>187</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="scrollAreaLayout">
@@ -401,6 +367,120 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tab_Advanced">
+      <attribute name="title">
+       <string>Advanced</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>The following options are primarily meant for debugging or as potential optimizations:</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_autoCompleteAddressBar">
+         <property name="text">
+          <string>Auto complete paths in address bar</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_teletypeConversion">
+         <property name="toolTip">
+          <string>Display teletype character codes properly in browse mode. Disable for faster loading of larger files</string>
+         </property>
+         <property name="text">
+          <string>Display teletype colors</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_syntaxHighlighting">
+         <property name="toolTip">
+          <string>Enable syntax highlighting. Disable for faster loading of larger files</string>
+         </property>
+         <property name="text">
+          <string>Enable syntax highlighting</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_parseLinks">
+         <property name="toolTip">
+          <string>Parse files for links to other files. Disable for faster loading of larger files</string>
+         </property>
+         <property name="text">
+          <string>Parse links</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="formLayout_2">
+         <item row="0" column="0">
+          <widget class="QLabel" name="labelLineLimit">
+           <property name="toolTip">
+            <string>Number of lines to display before truncating the file. Extremely large files can lead to application lag. If a file is truncated, it will not be editable.</string>
+           </property>
+           <property name="text">
+            <string>Line Limit:</string>
+           </property>
+           <property name="buddy">
+            <cstring>lineLimitSpinBox</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <layout class="QHBoxLayout" name="lineLimitHLayout">
+           <item>
+            <widget class="QSpinBox" name="lineLimitSpinBox">
+             <property name="toolTip">
+              <string>Number of lines to display before truncating the file. Extremely large files can lead to application lag. If a file is truncated, it will not be editable.</string>
+             </property>
+             <property name="maximum">
+              <number>100000000</number>
+             </property>
+             <property name="value">
+              <number>10000</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="lineLimitHSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
@@ -417,14 +497,10 @@
  </widget>
  <tabstops>
   <tabstop>tabWidget</tabstop>
-  <tabstop>checkBox_parseLinks</tabstop>
   <tabstop>checkBox_newTab</tabstop>
-  <tabstop>checkBox_syntaxHighlighting</tabstop>
-  <tabstop>checkBox_teletypeConversion</tabstop>
   <tabstop>checkBox_lineNumbers</tabstop>
   <tabstop>checkBox_showAllMessages</tabstop>
   <tabstop>checkBox_showHiddenFiles</tabstop>
-  <tabstop>checkBox_autoCompleteAddressBar</tabstop>
   <tabstop>useSpacesCheckBox</tabstop>
   <tabstop>useSpacesSpinBox</tabstop>
   <tabstop>themeWidget</tabstop>
@@ -434,6 +510,11 @@
   <tabstop>lineEdit</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>buttonNewProg</tabstop>
+  <tabstop>checkBox_autoCompleteAddressBar</tabstop>
+  <tabstop>checkBox_teletypeConversion</tabstop>
+  <tabstop>checkBox_syntaxHighlighting</tabstop>
+  <tabstop>checkBox_parseLinks</tabstop>
+  <tabstop>lineLimitSpinBox</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>

--- a/usdmanager/version.py
+++ b/usdmanager/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = '0.6.0'
+__version__ = '0.7.0'


### PR DESCRIPTION
[BUG] Progress bar works when reading USDZ files
[BUG] Find case sensitivity preference saves properly
[BUG] Do not prompt to save when opening a new file
[BUG] Windows support for usdcat and unzipping USDZ
[ENH] Add line limit user preference for loading large files
[ENH] Preferences and defaults maintenance, Advanced tab added to Preferences

Version up to 0.7.0

Preferences and defaults no longer maintained in two separate places. Changing
preferences no longer force reloads your current tab. Line limit increased from
10,000 to 50,000, with a user preference added to override this.

Switch to zipfile module instead of unzip command for reading USDZ

Signed-off-by: mds-dwa <mark.sandell@dreamworks.com>