### PR TITLE
Release version 0.9.0

### DIFF
--- a/scripts/usdmanager
+++ b/scripts/usdmanager
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from usdmanager import App
+from usdmanager import run
 
 if __name__ == "__main__":
-    App().run()
+    run()

--- a/usdmanager/constants.py
+++ b/usdmanager/constants.py
@@ -42,7 +42,7 @@ HTML_BODY = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.o
 <html><head><style type="text/css">
 a.mayNotExist {{color:#C90}}
 a.binary {{color:#69F}}
-span.badLink {{color:red}}
+.badLink {{color:red}}
 </style></head><body style="white-space:pre">{}</body></html>"""
 
 # Set a length limit on parsing for links and syntax highlighting on long lines. 999 chosen semi-arbitrarily to speed

--- a/usdmanager/version.py
+++ b/usdmanager/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = '0.8.0'
+__version__ = '0.9.0'


### PR DESCRIPTION
[ENH] Cache converted crate and zip files for faster repeat access
[ENH] Missing file links allow you to create the file
[ENH] When opening a * file path, don't open file browser dialog if files found
      Only open the file browser once if just directories are found
[ENH] Handle blank tabs more gracefully when restoring old tabs
[ENH] Tab icons persist throughout the app
[ENH] Cleanup files on KeyboardInterrupt
[ENH] Add tab-specific history menus to navigation buttons
[ENH] Improve saving user preferences
      Browse history reflects latest items instead of latest closed session
[BUG] File > Open Recent should not replace the current tab
[MNT] Minor PEP-8 conformance

Version up to 0.9.0

Signed-off-by: mds-dwa <mark.sandell@dreamworks.com>