### PR TITLE
Added check for Ar 2.0 method ConfigureResolverForAsset

### DIFF
--- a/usdmanager/utils.py
+++ b/usdmanager/utils.py
@@ -75,7 +75,10 @@ def expandPath(path, parentPath=None, sdf_format_args=None, extractedDir=None):
     
     if resolver is not None:
         try:
-            resolver.ConfigureResolverForAsset(path)
+            # ConfigureResolverForAsset no longer exists under Ar 2.0;
+            # this check is here for backwards compatibility with Ar 1.0
+            if hasattr(resolver, "ConfigureResolverForAsset"):
+                resolver.ConfigureResolverForAsset(path)
             context = resolver.CreateDefaultContextForAsset(path)
             with Ar.ResolverContextBinder(context):
                 anchoredPath = path if parentPath is None else resolver.AnchorRelativePath(parentPath, path)


### PR DESCRIPTION
As of `USD v0.21.8`, the method `ConfigureResolverForAsset` (among others) is now removed under the `Ar v2.0` API. This PR adds a check to the single usage of the method in a similar way it is done throughout USD (see commit https://github.com/PixarAnimationStudios/USD/commit/178bd78c78a7980967cdad6aa8928200891f378d for example).