### PR TITLE
Do not escape usd matching lines

### DIFF
--- a/usdmanager/parser.py
+++ b/usdmanager/parser.py
@@ -166,7 +166,8 @@ class FileParser(QObject):
         html = ""
         # Escape HTML characters for proper display.
         # Do this before we add any actual HTML characters.
-        lines = [escape(x) for x in self.text]
+        # Because USD identifiers may use `&`, ignore USD matching lines.
+        lines = [x if finditer(x) else escape(x) for x in self.text]
         for i, line in enumerate(lines):
             if self._stop:
                 # If the user has requested to stop, load the rest of the document


### PR DESCRIPTION
Referencing statements in the form of uris may use special characters which will be escaped by `cgi.escape`, leading to broken links.