### PR TITLE
Fixed links for ambiguous USD exts to crate files under Python 3

### DIFF
--- a/usdmanager/utils.py
+++ b/usdmanager/utils.py
@@ -390,8 +390,8 @@ def isUsdCrate(path):
     :Rtype:
         `bool`
     """
-    with open(path) as f:
-        return f.readline().startswith("PXR-USDC")
+    with open(path, "rb") as f:
+        return f.read(8).decode("utf-8") == "PXR-USDC"
 
 
 def isUsdExt(ext):


### PR DESCRIPTION
This PR resolves an issue under Python 3, in which URIs to crate files with ambiguous USD file extensions (`.usd`) would fail to parse and fail silently as so:
![image](https://user-images.githubusercontent.com/9414994/143824448-0e44b71f-c1b2-4ad4-9f82-68952de04e76.png)
```console
Error: 'utf-8' codec can't decode byte 0xc0 in position 100: invalid start byte
```

The fix avoids reading any further than the 8 characters of the file header.