### PR TITLE
Added various Python 2/3 compatibility changes

### DIFF
--- a/usdmanager/__init__.py
+++ b/usdmanager/__init__.py
@@ -798,8 +798,8 @@ a.binary {{color:#69F}}
         self.config.setValue("autoIndent", self.preferences['autoIndent'])
         
         # Write self.programs to settings object
-        exts = self.programs.keys()
-        progs = self.programs.values()
+        exts = list(self.programs.keys())
+        progs = list(self.programs.values())
         self.config.beginWriteArray("programs")
         for i in range(len(progs)):
             self.config.setArrayIndex(i)

--- a/usdmanager/linenumbers.py
+++ b/usdmanager/linenumbers.py
@@ -17,10 +17,15 @@
 Line numbers widget for optimized display of line numbers on the left side of
 a text widget.
 """
+from __future__ import division
+
 from Qt import QtCore
 from Qt.QtCore import QRect, QSize, Slot
 from Qt.QtGui import QColor, QFont, QPainter, QTextCharFormat, QTextFormat
 from Qt.QtWidgets import QTextEdit, QWidget
+
+# Shadow round for Python 3 compatibility
+from .utils import round as round
 
 
 class PlainTextLineNumbers(QWidget):

--- a/usdmanager/utils.py
+++ b/usdmanager/utils.py
@@ -20,6 +20,7 @@ import importlib
 import logging
 import os
 import re
+import math
 import subprocess
 import tempfile
 from contextlib import contextmanager
@@ -392,6 +393,27 @@ def isUsdCrate(path):
     """
     with open(path, "rb") as f:
         return f.read(8).decode("utf-8") == "PXR-USDC"
+
+
+def round(value, decimals=0):
+    """ Python 2/3 compatible rounding function. Lifted from
+    http://python3porting.com/differences.html#rounding-behavior
+
+    :Parameters:
+        value : `float`
+            The value to perform the rounding operation on.
+        decimals : `int`
+            The number of decimal places to retain.
+    :Returns:
+        The rounded value.
+    :Rtype:
+        `float`
+    """
+    p = 10 ** decimals
+    if value > 0:
+        return float(math.floor((value * p) + 0.5)) / p
+    else:
+        return float(math.ceil((value * p) - 0.5)) / p
 
 
 def isUsdExt(ext):

--- a/usdmanager/utils.py
+++ b/usdmanager/utils.py
@@ -20,6 +20,7 @@ import importlib
 import logging
 import os
 import re
+import sys
 import math
 import subprocess
 import tempfile
@@ -395,6 +396,17 @@ def isUsdCrate(path):
         return f.read(8).decode("utf-8") == "PXR-USDC"
 
 
+def isPy3():
+    """ Check if the application is running Python 3.
+    
+    :Returns:
+        If the application is running Python 3.
+    :Rtype:
+        `bool`
+    """
+    return sys.version_info[0] == 3
+
+
 def round(value, decimals=0):
     """ Python 2/3 compatible rounding function. Lifted from
     http://python3porting.com/differences.html#rounding-behavior
@@ -460,7 +472,10 @@ def loadUiType(uiFile, sourceFile=None, className="DefaultWidgetClass"):
     """
     import sys
     import xml.etree.ElementTree as xml
-    from StringIO import StringIO
+    if isPy3():
+        from io import StringIO
+    else:
+        from StringIO import StringIO
     from Qt import QtWidgets
     
     if not os.path.exists(uiFile) and not os.path.isabs(uiFile):
@@ -486,7 +501,7 @@ def loadUiType(uiFile, sourceFile=None, className="DefaultWidgetClass"):
         frame = {}
         uic.compileUi(f, o, indent=0)
         pyc = compile(o.getvalue(), "<string>", "exec")
-        exec pyc in frame
+        exec(pyc) in frame
         
         # Fetch the base_class and form class based on their type.
         form_class = frame["Ui_{}".format(form_class)]


### PR DESCRIPTION
This PR contains a series of compatibility changes that allow for relatively similar behaviour between Python 2 and 3.

Primarily this takes the form of fixes for division and rounding, as well as differing imports. Two utility functions have been added to accommodate this: `round()` (to ensure matching rounding operations between Python versions) and `isPy3()` (in lieu of adding the whole of the `Six` library for that check).