### PR TITLE
Updates for Windows & Ar 2.0: ResolvedPath, Win drive letters

### DIFF
--- a/usdmanager/include_panel.py
+++ b/usdmanager/include_panel.py
@@ -240,7 +240,8 @@ class IncludePanel(QtWidgets.QWidget):
     
     def setDirectory(self, directory):
         with overrideCursor():
-            if not directory.endswith('/'):
+            directory = str(directory) # it may be a ResolvedPath; convert to str
+            if not (directory.endswith('/') or directory.endswith('\\')):
                 directory += '/'
             self.fileNameEdit.completer().setCompletionPrefix(directory)
             root = self.fileModel.setRootPath(directory)


### PR DESCRIPTION
- Windows links to drive-based files need three leading slashes
- Ar 2.0 no longer has `AnchorRelativePath`; replace w/ `CreateIdentifier`
- expandPath returns a `ResolvedPath` that needs to be converted to
  string before being passed to python in a couple of places

Signed-off-by: Gary Oberbrunner <garyo@darkstarsystems.com>