### PR TITLE
Support relative resolved paths and uri-style assets

### DIFF
--- a/usdmanager/parser.py
+++ b/usdmanager/parser.py
@@ -146,6 +146,7 @@ class FileParser(QObject):
                 r'[^\t\n\r\f\v\'"]*?'         # 0 or more (greedy) non-whitespace characters (regular spaces are ok) and no quotes followed by a period, then 1 of the acceptable file extensions.
                 r'\.(?:'+'|'.join(exts)+r')'  # followed by a period, then 1 of the acceptable file extensions
                 r'|\${[\w/${}:.-]+}'          # One or more of these characters -- A-Za-z0-9_-/${}:. -- inside the variable curly brackets -- ${}
+                r'|[a-z]+[:]/[^\'"@]+'        # An Asset URI/IRI
             r')'                              # end group 1
             r'(?:[\'"@]|\\\")'  # 1 of: single quote, double quote, backslash followed by double quote, or at symbol.
         )

--- a/usdmanager/utils.py
+++ b/usdmanager/utils.py
@@ -723,6 +723,7 @@ def usdRegEx(exts):
             r'[^\t\n\r\f\v\'"]*?'         # 0 or more (greedy) non-whitespace characters (regular spaces are ok) and no quotes followed by a period, then 1 of the acceptable file extensions. NOTE: Backslash exclusion removed for Windows support; make sure this doesn't negatively affect other systems.
             r'\.(?:'+'|'.join(exts)+r')'  # followed by a period, then 1 of the acceptable file extensions
             r'|\${[\w/${}:.-]+}'          # One or more of these characters -- A-Za-z0-9_-/${}:. -- inside the variable curly brackets -- ${}
+            r'|[a-z]+[:]/[^\'"@]+'       # An Asset URI/IRI
         r')'                              # end group 1
         r'(?:\[(.*?)\])?'                 # Optional layer reference for a usdz file as group 2. TODO: Figure out how to only match this if the extension matched was .usdz (e.g. foo.usdz[path/to/file/within/package.usd])
         r'(?::SDF_FORMAT_ARGS:(.*?))?'    # Optional :SDF_FORMAT_ARGS:key=value&foo=bar, with the query string parameters as group 3

--- a/usdmanager/utils.py
+++ b/usdmanager/utils.py
@@ -130,7 +130,8 @@ def expandPath(path, parentPath=None, sdf_format_args=None, extractedDir=None):
                 if parentPath is None:
                     anchoredPath = path
                 elif hasattr(resolver, "CreateIdentifier"):
-                    anchoredPath = resolver.CreateIdentifier(path)
+                    anchor = resolver.Resolve(parentPath)
+                    anchoredPath = resolver.CreateIdentifier(path, anchor)
                 else:
                     anchoredPath = resolver.AnchorRelativePath(parentPath, path)
                 resolved = resolver.Resolve(anchoredPath)


### PR DESCRIPTION
The first commit updates the regular expression usdmanager uses to identify references. Previously it did not recognize uri style paths, which are supported by under ArResolver2.0.

The second commit updates the ArResolver2.0 code path to use the source as an anchor. This allows relative references to work
with non-filename asset references. Usd Manager has some internal path manipulation to allow relative paths to work with plain file paths, but it needs to use the resolver plugin for non file paths. This logic already exists when dealing with the ArResolver1.0 API, but when the 2.0 support was added this was overlooked.