### PR TITLE
Make the icon installation optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,13 +67,15 @@ setup(
     data_files=[("usdmanager", ["usdmanager/usdviewstyle.qss"])],
     scripts=glob("scripts/*"),
     install_requires=[
-        "crystal_small",  # Default icons
         "Qt.py>=1.1",
         "setuptools",  # For pkg_resources
     ],
     setup_requires=[
         "setuptools>=2.2",
     ],
+    extras_require={
+        'icons': ["crystal_small"],
+    },
     tests_require=[],
     dependency_links=[],
 )


### PR DESCRIPTION
Hej,

we do not want to install the icons, so I made the icon installation optional. Would this be a change you accept? If yes, I would add docs etc.

one would install with:

pip install usdmanager[icons]

Many thanks!

Sebastian