### PR TITLE
PyQt vs. PySide QFontDialog.getFont difference

### DIFF
--- a/usdmanager/__init__.py
+++ b/usdmanager/__init__.py
@@ -3862,9 +3862,9 @@ class TabBar(QtWidgets.QTabBar):
         drag = QtGui.QDrag(self)
         drag.setPixmap(self.style().standardIcon(QtWidgets.QStyle.SP_ArrowUp).pixmap(12, 12))
         mimeData = QtCore.QMimeData()
-        mimeData.setData("action", "moveTab")
+        mimeData.setData("action", QtCore.QByteArray(b"moveTab"))
         # Set the source window index so we know which window the drag/drop came from.
-        mimeData.setData("window", str(self.currentWindowIndex()))
+        mimeData.setData("window", QtCore.QByteArray(str(self.currentWindowIndex()).encode('utf-8')))
         drag.setMimeData(mimeData)
         drag.exec_()
 
@@ -3877,7 +3877,7 @@ class TabBar(QtWidgets.QTabBar):
         """
         mime = e.mimeData()
         formats = mime.formats()
-        if "action" in formats and "window" in formats and mime.data("action") == "moveTab":
+        if "action" in formats and "window" in formats and mime.data("action") == b"moveTab":
             e.acceptProposedAction()
 
     def currentWindowIndex(self):

--- a/usdmanager/preferences_dialog.py
+++ b/usdmanager/preferences_dialog.py
@@ -17,6 +17,7 @@
 """ Create a Preferences dialog.
 """
 
+import Qt
 from Qt.QtCore import Slot, QRegExp
 from Qt.QtGui import QRegExpValidator
 from Qt.QtWidgets import QAbstractButton, QDialog, QDialogButtonBox, QFontDialog, QLineEdit, QMessageBox, QVBoxLayout
@@ -376,7 +377,11 @@ class PreferencesDialog(QDialog):
     def selectFont(self, *args):
         """ Update the user's font preference.
         """
-        font, ok = QFontDialog.getFont(self.docFont, self, "Select Font")
+        result = QFontDialog.getFont(self.docFont, self, "Select Font")
+        if Qt.IsPyQt4 or Qt.IsPyQt5:
+            font, ok = result
+        else:
+            ok, font = result
         if ok:
             self.docFont = font
             self.updateFontLabel()


### PR DESCRIPTION
This fixes an issue with dragging tabs in PySide2 and python3 on Mac. Test by click-dragging any open tab. Drag/drop the tab on top of another tab in a second window to fully test the fix.
```
Traceback (most recent call last):
  File "/Users/Mark/.local/lib/python3.10/site-packages/usdmanager-0.15.0-py3.10.egg/usdmanager/__init__.py", line 3865, in mouseMoveEvent
    mimeData.setData("action", "moveTab")
TypeError: 'PySide2.QtCore.QMimeData.setData' called with wrong argument types:
  PySide2.QtCore.QMimeData.setData(str, str)
Supported signatures:
  PySide2.QtCore.QMimeData.setData(str, PySide2.QtCore.QByteArray)
```

This also fixes a bug with font selection in the Preferences dialog in PySide1/2. This appears to be a difference between PyQt and PySide, returning font and ok in a different order. Test by going to Preferences and changing the font, watching for any terminal errors.
```
Traceback (most recent call last):
  File "/Users/Mark/.local/lib/python3.10/site-packages/usdmanager-0.15.0-py3.10.egg/usdmanager/preferences_dialog.py", line 382, in selectFont
    self.updateFontLabel()
  File "/Users/Mark/.local/lib/python3.10/site-packages/usdmanager-0.15.0-py3.10.egg/usdmanager/preferences_dialog.py", line 387, in updateFontLabel
    bold = "Bold " if self.docFont.bold() else ""
AttributeError: 'bool' object has no attribute 'bold'
```