### PR TITLE
Add Raw View mode for improved performance with heavy USD files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@
 # serve to show the default.
 
 import os
-from recommonmark.parser import CommonMarkParser
 import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -33,6 +32,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'sphinxcontrib.apidoc',
+    'recommonmark',
 ]
 
 autodoc_mock_imports = [
@@ -42,28 +42,27 @@ autodoc_mock_imports = [
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
-source_parsers = {
-    '.md': CommonMarkParser,
-}
-
 # The suffix of source filenames.
-source_suffix = ['.rst', '.md']
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+root_doc = 'index'
 
 # General information about the project.
-project = u'USD Manager'
-copyright = u'2019, DreamWorks Animation'
+project = 'USD Manager'
+copyright = '2019, DreamWorks Animation'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-execfile("../usdmanager/version.py")
+from usdmanager.version import __version__
 # The short X.Y version.
 version = __version__
 # The full version, including alpha/beta/rc tags.
@@ -118,7 +117,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -216,8 +215,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'USDManager.tex', u'USD Manager Documentation',
-   u'DreamWorks Animation', 'manual'),
+  ('index', 'USDManager.tex', 'USD Manager Documentation',
+   'DreamWorks Animation', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -246,8 +245,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'usdmanager', u'USD Manager Documentation',
-     [u'DreamWorks Animation'], 1)
+    ('index', 'usdmanager', 'USD Manager Documentation',
+     ['DreamWorks Animation'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -260,8 +259,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'USDManager', u'USD Manager Documentation',
-   u'DreamWorks Animation', 'USDManager', 'One line description of project.',
+  ('index', 'USDManager', 'USD Manager Documentation',
+   'DreamWorks Animation', 'USDManager', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/keyboardShortcuts.rst
+++ b/docs/keyboardShortcuts.rst
@@ -104,6 +104,8 @@ For ease of use, there are some extra shortcuts not shown in the menus themselve
      - Ctrl+Tab
    * - Previous Tab
      - Ctrl+Shift+Tab
+   * - Raw View
+     - Ctrl+Shift+V
    * - Reload
      - F5
    * - Indent (if text is selected)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 recommonmark>=0.5.0
 Sphinx>=1.8.5
 sphinxcontrib-apidoc>=0.3.0
+sphinx-rtd-theme

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,7 @@ usdmanager shot.usd
 
 - [Browse Mode](#browse-mode)
   * [Browsing Standard Features](#browsing-standard-features)
+  * [Raw View Mode](#raw-view-mode)
 - [Edit Mode](#edit-mode)
   * [Editing Standard Features](#editing-standard-features)
 - [USD Crate](#usd-crate)
@@ -47,6 +48,12 @@ Binary USD Crate files are highlighted in purple instead of blue.
 The browser boasts many standard features, including tabbed browsing with rearrangeable tabs, a navigational history
 per tab, a recent files list (File > Open Recent), and the ability to restore closed Tabs (History > Recently Closed
 Tabs).
+
+### Raw View Mode
+For improved performance with large files, you can enable Raw View mode by clicking the "Raw View" button or using 
+Ctrl+Shift+V. Raw View disables syntax highlighting and link parsing, making file loading and scrolling significantly 
+faster. To exit Raw View, click "Disable Raw View" or use Ctrl+Shift+V again. You can set Raw View as the default for 
+new tabs in the Advanced preferences.
 
 ## Edit Mode
 

--- a/usdmanager/__init__.py
+++ b/usdmanager/__init__.py
@@ -374,6 +374,7 @@ a.binary {{color:#69F}}
         textEdit = icon("accessories-text-editor")
         self.actionEdit.setIcon(textEdit)
         self.actionTextEditor.setIcon(textEdit)
+        self.actionRawView.setIcon(textEdit)
         self.buttonGo.setIcon(icon("media-playback-start"))
         self.actionFullScreen.setIcon(icon("view-fullscreen"))
         self.browserReloadIcon = icon("view-refresh")
@@ -537,6 +538,8 @@ a.binary {{color:#69F}}
         # Add one of our special tabs.
         self.currTab = self.newTab()
         self.setNavigationMenus()
+        
+        self.updateEditButtons()
 
         # Adjust tab order.
         self.setTabOrder(self.addressBar, self.includeWidget.listView)
@@ -599,6 +602,9 @@ a.binary {{color:#69F}}
             logger.debug("Setting highlighter to %s", ext)
             tab.highlighter.deleteLater()
             tab.highlighter = highlighter.Highlighter(tab.getCurrentTextWidget().document(), master)
+        
+        enableHighlighting = self.preferences['syntaxHighlighting'] and not tab.inRawView
+        tab.highlighter.master.setSyntaxHighlighting(enableHighlighting)
 
     @Slot(QtCore.QPoint)
     def customTextBrowserContextMenu(self, pos):
@@ -727,6 +733,7 @@ a.binary {{color:#69F}}
         default = self.app.DEFAULTS
         self.preferences = {
             'parseLinks': self.config.boolValue("parseLinks", default['parseLinks']),
+            'rawViewDefault': self.config.boolValue("rawViewDefault", default['rawViewDefault']),
             'newTab': self.config.boolValue("newTab", default['newTab']),
             'syntaxHighlighting': self.config.boolValue("syntaxHighlighting", default['syntaxHighlighting']),
             'teletype': self.config.boolValue("teletype", default['teletype']),
@@ -809,6 +816,7 @@ a.binary {{color:#69F}}
         """
         logger.debug("Writing user settings to %s", self.config.fileName())
         self.config.setValue("parseLinks", self.preferences['parseLinks'])
+        self.config.setValue("rawViewDefault", self.preferences['rawViewDefault'])
         self.config.setValue("newTab", self.preferences['newTab'])
         self.config.setValue("syntaxHighlighting", self.preferences['syntaxHighlighting'])
         self.config.setValue("teletype", self.preferences['teletype'])
@@ -907,6 +915,7 @@ a.binary {{color:#69F}}
         # Edit Menu
         self.actionEdit.triggered.connect(self.toggleEdit)
         self.actionBrowse.triggered.connect(self.toggleEdit)
+        self.actionRawView.triggered.connect(self.toggleRawView)
         self.actionUndo.triggered.connect(self.undo)
         self.actionRedo.triggered.connect(self.redo)
         self.actionCut.triggered.connect(self.cut)
@@ -1681,6 +1690,8 @@ a.binary {{color:#69F}}
             vScrollPos = tab.textBrowser.verticalScrollBar().value()
             tab.textBrowser.setVisible(False)
             tab.textEditor.setVisible(True)
+            tab.textEditor.setReadOnly(False)
+            
             tab.textEditor.setFocus()
             tab.textEditor.horizontalScrollBar().setValue(hScrollPos)
             tab.textEditor.verticalScrollBar().setValue(vScrollPos)
@@ -1694,11 +1705,20 @@ a.binary {{color:#69F}}
             # be safe, but this can be slow.
             refreshed = self.refreshTab(tab=tab)
 
-            tab.textEditor.setVisible(False)
-            tab.textBrowser.setVisible(True)
-            tab.textBrowser.setFocus()
-            tab.textBrowser.horizontalScrollBar().setValue(hScrollPos)
-            tab.textBrowser.verticalScrollBar().setValue(vScrollPos)
+            if tab.inRawView:
+                tab.textEditor.setVisible(True)
+                tab.textBrowser.setVisible(False)
+                tab.textEditor.setReadOnly(True)
+                tab.textEditor.setFocus()
+                tab.textEditor.horizontalScrollBar().setValue(hScrollPos)
+                tab.textEditor.verticalScrollBar().setValue(vScrollPos)
+            else:
+                tab.textEditor.setVisible(False)
+                tab.textBrowser.setVisible(True)
+                
+                tab.textBrowser.setFocus()
+                tab.textBrowser.horizontalScrollBar().setValue(hScrollPos)
+                tab.textBrowser.verticalScrollBar().setValue(vScrollPos)
 
         # Don't double-up the below commands if we already refreshed the tab.
         if not refreshed:
@@ -1710,6 +1730,51 @@ a.binary {{color:#69F}}
         self.findRehighlightAll()
         if tab == self.currTab:
             self.editModeChanged.emit(tab.inEditMode)
+        return True
+
+    @Slot()
+    def toggleRawView(self, checked=False, tab=None):
+        """ Switch between normal Browse mode and Raw View mode.
+
+        :Parameters:
+            checked : `bool`
+                Unused. For signal/slot only
+            tab : `BrowserTab`
+                Tab to toggle raw view mode on
+        :Returns:
+            True if we switched modes; otherwise, False.
+        :Rtype:
+            `bool`
+        """
+        tab = tab or self.currTab
+        if not tab:
+            return False
+
+        if tab.inEditMode:
+            return False
+        
+        tab.inRawView = not tab.inRawView
+        
+        enableHighlighting = self.preferences['syntaxHighlighting'] and not tab.inRawView
+        if tab.highlighter:
+            tab.highlighter.master.setSyntaxHighlighting(enableHighlighting)
+        
+        self.refreshTab(tab=tab)
+        
+        if not tab.inEditMode:
+            if tab.inRawView:
+                tab.textBrowser.setVisible(False)
+                tab.textEditor.setVisible(True)
+                tab.textEditor.setReadOnly(True)
+                tab.textEditor.setFocus()
+            else:
+                tab.textEditor.setVisible(False)
+                tab.textBrowser.setVisible(True)
+                tab.textBrowser.setFocus()
+        
+        if tab == self.currTab:
+            self.updateEditButtons()
+        
         return True
 
     @Slot()
@@ -2196,6 +2261,7 @@ a.binary {{color:#69F}}
             self.preferences['newTab'] = dlg.getPrefNewTab()
             self.preferences['lineNumbers'] = dlg.getPrefLineNumbers()
             self.preferences['showAllMessages'] = dlg.getPrefShowAllMessages()
+            self.preferences['rawViewDefault'] = dlg.getPrefRawViewDefault()
             self.preferences['showHiddenFiles'] = dlg.getPrefShowHiddenFiles()
             self.preferences['autoCompleteAddressBar'] = dlg.getPrefAutoCompleteAddressBar()
             self.preferences['textEditor'] = dlg.getPrefTextEditor()
@@ -3054,17 +3120,33 @@ a.binary {{color:#69F}}
                         # Stop Loading Tab stops the expensive parsing of the file
                         # for links, checking if the links actually exist, etc.
                         # Setting it to this bypasses link parsing if the tab is in edit mode.
-                        parser.stop(tab.inEditMode or not self.preferences['parseLinks'])
+                        shouldStop = tab.inEditMode or tab.inRawView or not self.preferences['parseLinks']
+                        parser.stop(shouldStop)
                         self.actionStop.setEnabled(True)
 
                         parser.parse(nativeAbsPath, fileInfo, link)
                         tab.fileFormat = parser.fileFormat
                         self.tabWidget.setTabIcon(idx, parser.icon)
                         self.setHighlighter(ext, tab=tab)
-                        logger.debug("Setting HTML")
-                        tab.textBrowser.setHtml(parser.html)
-                        logger.debug("Setting plain text")
-                        tab.textEditor.setPlainText("".join(parser.text))
+                        
+                        if tab.inEditMode:
+                            # Edit mode: textEditor visible, textBrowser hidden
+                            logger.debug("Setting plain text (Edit Mode)")
+                            tab.textEditor.setPlainText("".join(parser.text))
+                            tab.textEditor.setReadOnly(False)  # Enable editing
+                        elif tab.inRawView:
+                            # Raw View mode: Use textEditor for fast plain text display
+                            logger.debug("Setting plain text (Raw View Mode)")
+                            tab.textEditor.setVisible(True)
+                            tab.textBrowser.setVisible(False)
+                            tab.textEditor.setPlainText("".join(parser.text))
+                            tab.textEditor.setReadOnly(True)
+                        else:
+                            # Normal View mode: textBrowser visible for HTML display
+                            logger.debug("Setting HTML (Normal View Mode)")
+                            tab.textBrowser.setVisible(True)
+                            tab.textEditor.setVisible(False)
+                            tab.textBrowser.setHtml(parser.html)
                         truncated = parser.truncated
                         warning = parser.warning
                         parser.cleanup()
@@ -3085,8 +3167,19 @@ a.binary {{color:#69F}}
             else:
                 # Load an empty tab pointing to the nonexistent file.
                 self.setHighlighter(ext, tab=tab)
-                tab.textBrowser.setHtml("")
-                tab.textEditor.setPlainText("")
+                
+                if tab.inEditMode:
+                    tab.textEditor.setPlainText("")
+                    tab.textEditor.setReadOnly(False)
+                elif tab.inRawView:
+                    tab.textEditor.setVisible(True)
+                    tab.textBrowser.setVisible(False)
+                    tab.textEditor.setPlainText("")
+                    tab.textEditor.setReadOnly(True)
+                else:
+                    tab.textBrowser.setVisible(True)
+                    tab.textEditor.setVisible(False)
+                    tab.textBrowser.setHtml("")
                 truncated = False
                 warning = None
 
@@ -3408,6 +3501,8 @@ a.binary {{color:#69F}}
             self.actionUncomment.setEnabled(True)
             self.actionIndent.setEnabled(True)
             self.actionUnindent.setEnabled(True)
+            self.actionRawView.setEnabled(False)
+            self.actionRawView.setText("Raw View")
         else:
             self.actionEdit.setVisible(True)
             self.actionBrowse.setVisible(False)
@@ -3422,6 +3517,8 @@ a.binary {{color:#69F}}
             self.actionUncomment.setEnabled(False)
             self.actionIndent.setEnabled(False)
             self.actionUnindent.setEnabled(False)
+            self.actionRawView.setEnabled(True)
+            self.actionRawView.setText("Raw View" if not self.currTab.inRawView else "Disable Raw View")
 
     @Slot(str)
     def validateAddressBar(self, address):
@@ -4343,6 +4440,7 @@ class BrowserTab(QtWidgets.QWidget):
             color = self.style().standardPalette().base().color().darker(105).name()
         self.setStyleSheet("QTextBrowser{{background-color:{}}}".format(color))
         self.inEditMode = False
+        self.inRawView = parent.window().preferences.get('rawViewDefault', False) if parent else False
         self.isActive = True  # Track if this tab is open or has been closed.
         self.isNewTab = True  # Track if this tab has been used for any files yet.
         self.setAcceptDrops(True)
@@ -4857,6 +4955,7 @@ class App(QtCore.QObject):
             'lineNumbers': True,
             'newTab': False,
             'parseLinks': True,
+            'rawViewDefault': False,
             'showAllMessages': True,
             'showHiddenFiles': False,
             'syntaxHighlighting': True,

--- a/usdmanager/main_window.ui
+++ b/usdmanager/main_window.ui
@@ -589,6 +589,7 @@
    <addaction name="separator"/>
    <addaction name="actionBrowse"/>
    <addaction name="actionEdit"/>
+   <addaction name="actionRawView"/>
   </widget>
   <widget class="QToolBar" name="navToolbar">
    <property name="windowTitle">
@@ -1031,6 +1032,22 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+E</string>
+   </property>
+  </action>
+  <action name="actionRawView">
+   <property name="icon">
+    <iconset theme="accessories-text-editor">
+     <normaloff/>
+    </iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Raw View</string>
+   </property>
+   <property name="statusTip">
+    <string>Switch to raw view mode (no link parsing or syntax highlighting)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+V</string>
    </property>
   </action>
   <action name="actionPreferences_SyntaxHighlighting">

--- a/usdmanager/parser.py
+++ b/usdmanager/parser.py
@@ -182,7 +182,10 @@ class FileParser(QObject):
         """
         self.cleanup()
         
-        self.status.emit("Reading file")
+        if self._stop:
+            return self.parseRawMode(nativeAbsPath)
+        
+        self.status.emit("Reading file (Normal Mode)")
         self.text = self.read(nativeAbsPath)
         
         # TODO: Figure out a better way to handle streaming text for large files like Crate geometry.
@@ -269,6 +272,26 @@ class FileParser(QObject):
             `str`
         """
         return HTML_BODY.format(text)
+    
+    def parseRawMode(self, nativeAbsPath):
+        """ Fast parsing for Raw View mode - bypasses link parsing and minimal HTML generation.
+        
+        :Parameters:
+            nativeAbsPath : `str`
+                OS-native absolute file path
+        """
+        self.status.emit("Reading file (Raw View Mode)")
+        self.text = self.read(nativeAbsPath)
+        
+        length = len(self.text)
+        if length > self.parent().preferences.get('lineLimit', 1000000):
+            limit = self.parent().preferences['lineLimit']
+            self.truncated = True
+            self.text = self.text[:limit]
+            self.warning = "Extremely large file! Capping display at {:,d} lines. You can edit this cap in the "\
+                          "Advanced tab of Preferences.".format(limit)
+        
+        self.parent().loadingProgressBar.setMaximum(length)
     
     def parseMatch(self, match, linkPath, nativeAbsPath, fileInfo):
         """ Parse a RegEx match of a patch to another file.

--- a/usdmanager/preferences_dialog.py
+++ b/usdmanager/preferences_dialog.py
@@ -60,6 +60,7 @@ class PreferencesDialog(QDialog):
         self.checkBox_parseLinks.setChecked(parent.preferences['parseLinks'])
         self.checkBox_newTab.setChecked(parent.preferences['newTab'])
         self.checkBox_syntaxHighlighting.setChecked(parent.preferences['syntaxHighlighting'])
+        self.checkBox_rawViewDefault.setChecked(parent.preferences['rawViewDefault'])
         self.checkBox_teletypeConversion.setChecked(parent.preferences['teletype'])
         self.checkBox_lineNumbers.setChecked(parent.preferences['lineNumbers'])
         self.checkBox_showAllMessages.setChecked(parent.preferences['showAllMessages'])
@@ -211,6 +212,16 @@ class PreferencesDialog(QDialog):
             `bool`
         """
         return self.checkBox_syntaxHighlighting.isChecked()
+
+    def getPrefRawViewDefault(self):
+        """ Get the user preference for Raw View mode as default.
+
+        :Returns:
+            State of "Default to Raw View mode" check box.
+        :Rtype:
+            `bool`
+        """
+        return self.checkBox_rawViewDefault.isChecked()
 
     def getPrefTeletypeConversion(self):
         """ Get the user preference to enable teletype character conversion.

--- a/usdmanager/preferences_dialog.ui
+++ b/usdmanager/preferences_dialog.ui
@@ -430,6 +430,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="checkBox_rawViewDefault">
+         <property name="toolTip">
+          <string>Start new tabs in Raw View mode by default for better performance with large files</string>
+         </property>
+         <property name="text">
+          <string>Default to Raw View mode</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QFormLayout" name="formLayout_2">
          <item row="0" column="0">
           <widget class="QLabel" name="labelLineLimit">
@@ -524,6 +534,7 @@
   <tabstop>checkBox_teletypeConversion</tabstop>
   <tabstop>checkBox_syntaxHighlighting</tabstop>
   <tabstop>checkBox_parseLinks</tabstop>
+  <tabstop>checkBox_rawViewDefault</tabstop>
   <tabstop>lineLimitSpinBox</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>


### PR DESCRIPTION
Usdmanager can be very slow when opening heavy usd files with lots of data. This is still the case when syntax highlighting and link parsing is turned off.
I narrowed this down to the setHtml() call on the TextBrowser that is taking most of the time.

With this PR I suggest adding a Raw View mode, that uses the TextEditor in read only mode instead of the TextBrowser, which leads to significant performance improvements, when loading heavy usd files.

I'm not sure how actively this repo is still maintained, so sorry if this is the wrong place for the PR.
Also you can ignore the changes in docs/conf.py and docs/requirements.txt, just wanted to match my documentation build to the official one.

<img width="3182" height="1720" alt="raw_view_button" src="https://github.com/user-attachments/assets/a5a95228-351e-4fb5-a794-a04a8e4dad36" />
<img width="3182" height="1720" alt="raw_view_enabled" src="https://github.com/user-attachments/assets/de76f7b0-ba22-43b9-899e-86ab097db987" />
<img width="3150" height="1688" alt="raw_view_preferences" src="https://github.com/user-attachments/assets/b9e02b1f-5420-4a88-87d2-8bcb635caefe" />


* Add Raw View mode for improved performance

- Use TextEditor instead of TextBrowser for Raw View mode to avoid HTML processing overhead.
- Disable syntax highlighting and link parsing in Raw View
- Add preference to default new tabs to Raw View mode

* Update documentation and configuration

- Add Raw View mode documentation to usage.md
- Add Raw View shortcut (Ctrl+Shift+V) to keyboard shortcuts
- Fix Sphinx configuration for Python 3 compatibility
- Modernize conf.py